### PR TITLE
Update undetected-chromedriver to version 3.5.5 and specify Chrome ve…

### DIFF
--- a/modules/scraper.py
+++ b/modules/scraper.py
@@ -230,7 +230,9 @@ class GoogleReviewsScraper:
         else:
             # On regular OS, use default undetected_chromedriver
             log.info("Using standard undetected_chromedriver setup")
-            driver = uc.Chrome(options=opts)
+            # Use version_main to match the installed Chrome version (141)
+            # Set to None to auto-detect, or specify explicitly like version_main=141
+            driver = uc.Chrome(options=opts, version_main=141, use_subprocess=True)
 
         # Set page load timeout to avoid hanging
         driver.set_page_load_timeout(30)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.12.3
 aiohttp==3.11.11
 googletrans==4.0.2
 selenium==4.15.2
-undetected-chromedriver==3.5.4
+undetected-chromedriver==3.5.5
 tqdm==4.66.3
 pymongo==4.12.0
 pyyaml==6.0.1


### PR DESCRIPTION
**Changes Made**
I made two key changes to fix the issue:

Updated undetected-chromedriver from version 3.5.4 to 3.5.5
Modified modules/scraper.py to explicitly specify the Chrome version (141) when initializing the driver:

**What Was the Problem?**
The error occurred because undetected_chromedriver was automatically downloading ChromeDriver version 142, but your installed Chrome browser is version 141.0.7390.123. By explicitly setting version_main=141, the driver now downloads and uses the correct ChromeDriver version that matches your browser.