### PR TITLE
fix: tab index == 1 doesnt return the review tab consistently

### DIFF
--- a/modules/scraper.py
+++ b/modules/scraper.py
@@ -442,7 +442,7 @@ class GoogleReviewsScraper:
         try:
             # Strategy 1: Data attribute detection (most reliable across languages)
             tab_index = tab.get_attribute("data-tab-index")
-            if tab_index == "1" or tab_index == "reviews":
+            if tab_index == "reviews":
                 return True
 
             # Strategy 2: Role and aria attributes (accessibility detection)


### PR DESCRIPTION
Hey @georgekhananaev,

Thanks for your work on this repo.

### Intent:

I found that `tab-index = "1"` used in the first strategy to find the review tab is unreliable, in my case it clicks on "Menu" which associates to this tab-index.

It might be located differently based on region?

See preview showing the Menu tab with tab-index = 1

<img width="863" height="870" alt="image" src="https://github.com/user-attachments/assets/4945d9c2-1023-4fd9-b24c-d3fd8dd3e06c" />


### Suggestion:

I am suggesting to drop entirely the index 1 from being matched for strategy #1, giving priority to more precise tab matching.

