### PR TITLE
Fix: don't penalize Reviews tab when place name contains a non-review…

### DIFF
--- a/modules/scraper.py
+++ b/modules/scraper.py
@@ -603,17 +603,25 @@ class GoogleReviewsScraper:
 
         score = 0.0
 
+        aria_has_review = _text_contains_any(aria_label, REVIEW_WORDS)
+        text_has_review = _text_contains_any(tab_text, REVIEW_WORDS)
+
         # Strongest signals — explicit semantic match.
-        if _text_contains_any(aria_label, REVIEW_WORDS):
+        if aria_has_review:
             score += 1.5
-        if _text_contains_any(tab_text, REVIEW_WORDS):
+        if text_has_review:
             score += 1.0
 
         # Penalize non-review labels — prevents Menu/Overview misclassification
         # when they happen to sit at data-tab-index="1".
-        if _text_contains_any(aria_label, NON_REVIEW_TAB_WORDS):
+        #
+        # IMPORTANT: only penalize when no review keyword matched. Aria-labels
+        # embed the place name ("Reviews for Caledon Community Services"), and
+        # place names can contain penalty words like "services" or "menu",
+        # which would wrongly cancel out a genuine match.
+        if not aria_has_review and _text_contains_any(aria_label, NON_REVIEW_TAB_WORDS):
             score -= 1.5
-        if _text_contains_any(tab_text, NON_REVIEW_TAB_WORDS):
+        if not text_has_review and _text_contains_any(tab_text, NON_REVIEW_TAB_WORDS):
             score -= 1.0
 
         # Weak positive: index + keyword already scored above; bare index


### PR DESCRIPTION
Closes #25 

## Problem

`_score_reviews_tab` rejects the genuine Reviews tab when the place name
contains a word from `NON_REVIEW_TAB_WORDS` (e.g. "services", "menu").

Google Maps aria-labels embed the place name: a place called
"Caledon Community Services" gets `aria-label="Reviews for Caledon
Community Services"`. The current scorer adds +1.5 for the "reviews"
match, then immediately subtracts 1.5 for "services", landing at 0.0
and falling under the 1.5 threshold. The tab is silently rejected.

This affected any place whose name contains a penalty word — common for
service businesses, restaurants with "menu" in the name, etc.

## Fix

Skip the penalty when a review keyword already matched in the same
field. The Menu-vs-Reviews protection from #17/#21 still works: a Menu
tab has no review keyword, so the penalty still fires and it still
gets rejected.

## Test

Reproduces with: https://maps.app.goo.gl/7EPKEs7rukXW2qVn7 (Caledon
Community Services). Before this change: 380 candidate tabs scored,
all rejected, scrape fails. After: tab found, clicked, reviews scrape
normally.