### PR TITLE
Return place_id and fix reviews_count in job response

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -271,6 +271,7 @@ class JobResponse(BaseModel):
     reviews_count: Optional[int] = None
     images_count: Optional[int] = None
     progress: Optional[Dict[str, Any]] = None
+    place_id: Optional[str] = None
 
 
 class JobStatsResponse(BaseModel):

--- a/modules/job_manager.py
+++ b/modules/job_manager.py
@@ -42,6 +42,7 @@ class ScrapingJob:
     progress: Dict[str, Any] = None
     cancel_event: threading.Event = None
     _scraper: Optional[Any] = None
+    place_id: Optional[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert job to dictionary for JSON serialization"""
@@ -57,6 +58,7 @@ class ScrapingJob:
             "reviews_count": self.reviews_count,
             "images_count": self.images_count,
             "progress": self.progress,
+            "place_id": self.place_id,
         }
         return data
 
@@ -181,6 +183,7 @@ class JobManager:
 
                 job.reviews_count = getattr(scraper, 'total_reviews', None)
                 job.images_count = getattr(scraper, 'total_images', None)
+                job.place_id = getattr(scraper, 'place_id', None)
                 job._scraper = None
 
             log.info(f"Completed scraping job {job_id}")

--- a/modules/scraper.py
+++ b/modules/scraper.py
@@ -247,6 +247,8 @@ class GoogleReviewsScraper:
         db_path = config.get("db_path", "reviews.db")
         self.review_db = ReviewDB(db_path)
         self._selector_health: SelectorHealth | None = None
+        self.place_id = None
+        self.total_reviews = None
 
     def _record_selector(self, selector: str, outcome: str) -> None:
         """Telemetry helper — always safe to call."""
@@ -1481,6 +1483,7 @@ class GoogleReviewsScraper:
             place_id = self.review_db.upsert_place(
                 place_id, place_name, url, resolved_url, lat_f, lng_f
             )
+            self.place_id = place_id
             session_id = self.review_db.start_session(place_id, sort_by)
             log.info(f"Registered place: {place_id} ({place_name})")
             self._selector_health = SelectorHealth(self.review_db.backend, session_id)
@@ -1825,6 +1828,7 @@ class GoogleReviewsScraper:
             total_found = sum(batch_stats.values())
             parse_errors = batch_stats.get("parse_errors", 0)
             real_found = total_found - parse_errors
+            self.total_reviews = real_found
             if session_id:
                 # Session status: "empty" if zero reviews extracted,
                 # "degraded" if >30% of cards failed parsing, else "completed".


### PR DESCRIPTION
## Problem

Two issues with the `JobResponse` returned by `POST /scrape` and `GET /jobs/{job_id}`:

### 1. Missing `place_id`

The response doesn't include `place_id`, which makes the API hard to use from clients, because every other useful endpoint (`/reviews/{place_id}`, `/places/{place_id}`) requires it.

Current workarounds are both bad:
- Iterate `GET /places` and string-match `original_url` against the submitted URL — slow, O(n).
- Try to match by `resolved_url` — but short links (`maps.app.goo.gl/...`) resolve to a different URL than the submitted one, so this often misses.

Clients can't read the SQLite DB directly (different host, no filesystem access in many deployments), so the only reliable option today is brittle URL parsing.

### 2. `reviews_count` always `None`

`job_manager.py` reads `getattr(scraper, 'total_reviews', None)`, but the scraper never sets `self.total_reviews`, so the field is always `None` in the response.

## Fix

Propagate `place_id` from the scraper out to the job response, and set `total_reviews` on the scraper so `job_manager` can read it. Both follow the existing `getattr`-based pattern:

1. `scraper.py`: assign `self.place_id` right after the place is registered in the DB, and `self.total_reviews` once the scrape completes
2. `job_manager.py`: include `place_id` alongside the existing `reviews_count`/`images_count` reads
3. `Job` dataclass + `to_dict()`: include the new `place_id` field
4. `api_server.py`: add `place_id: Optional[str] = None` to `JobResponse`

## Properties

- Backward-compatible — new optional field, nothing breaks for existing clients
- `place_id` available even on partial failures (e.g. driver crash after place registration but before reviews fully load), so clients still get a usable ID for follow-up queries
- Follows the convention already established for `reviews_count`/`images_count`
- No new coupling — scraper doesn't need to know about jobs

## Test

End-to-end tested locally: started a scrape via `POST /scrape`, polled `GET /jobs/{job_id}`, confirmed both `place_id` and `reviews_count` appear in the response on completion and match what's in `/places` and the DB respectively.