### PR TITLE
Fix WinError 123 on Windows: sanitize place_id before using it as a directory name

### DIFF
--- a/modules/image_handler.py
+++ b/modules/image_handler.py
@@ -147,10 +147,32 @@ class ImageHandler:
         self._has_session_cookies = True
         log.debug("ImageHandler: loaded %d browser cookies", len(cookies))
 
+    @staticmethod
+    def _fs_safe(place_id: str) -> str:
+        r"""Make a place id safe to use as a directory name.
+
+        A Google Maps feature id looks like `0x89accda1eff33585:0x8347540c3719d897`. Used as a
+        path component on Windows, the `x:` is read as a DRIVE specifier, so the path truncates
+        and `mkdir` fails with
+        `OSError: [WinError 123] The filename, directory name, or volume label syntax is
+        incorrect: 'review_images\0x89accda1eff33585:0\profiles'`.
+
+        The failure is quiet in the worst way: the scrape itself succeeds and every review is
+        stored, while the whole images task fails and zero files are written. On a run of 103
+        reviews nothing in the console indicated a problem.
+
+        Replaces every character Windows forbids in a path component. The mapping is
+        deterministic, so a directory created on one OS is found again on another.
+        """
+        safe = place_id
+        for ch in ':*?"<>|/\\':
+            safe = safe.replace(ch, "_")
+        return safe.strip(". ") or "unknown_place"
+
     def set_place_id(self, place_id: str):
         """Set place ID to organize images into per-business subdirectories."""
         self._place_id = place_id
-        base = self.image_dir / place_id
+        base = self.image_dir / self._fs_safe(place_id)
         self.profile_dir = base / "profiles"
         self.review_dir = base / "reviews"
 

--- a/modules/pipeline.py
+++ b/modules/pipeline.py
@@ -107,7 +107,7 @@ class S3Task(SyncTask):
             # Review images
             for filename in review.get("local_images", []):
                 if filename and filename not in files_to_upload:
-                    base = self._image_dir / place_id if place_id else self._image_dir
+                    base = self._image_dir / ImageHandler._fs_safe(place_id) if place_id else self._image_dir
                     local_path = base / "reviews" / filename
                     if local_path.exists():
                         files_to_upload[filename] = (local_path, False)
@@ -115,7 +115,7 @@ class S3Task(SyncTask):
             # Profile picture
             pp = review.get("local_profile_picture")
             if pp and pp not in files_to_upload:
-                base = self._image_dir / place_id if place_id else self._image_dir
+                base = self._image_dir / ImageHandler._fs_safe(place_id) if place_id else self._image_dir
                 local_path = base / "profiles" / pp
                 if local_path.exists():
                     files_to_upload[pp] = (local_path, True)


### PR DESCRIPTION
A Google Maps feature id contains a colon, e.g. `0x89accda1eff33585:0x8347540c3719d897`. On Windows that cannot be a path component: `x:` is read as a drive specifier, the path truncates, and `ImageHandler.ensure_directories()` raises

```
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect:
  'review_images\0x89accda1eff33585:0\profiles'
```

**The failure is quiet in the worst way.** The scrape itself succeeds and every review is written to SQLite, while the whole images task fails and zero files land on disk. On a run of 103 reviews the console gave no indication anything was wrong; it was only found by counting the files on disk afterwards.

### The fix

`ImageHandler._fs_safe()` replaces every character Windows forbids in a path component, applied in both places a per-place directory is built:

- `modules/image_handler.py` -> `set_place_id()`
- `modules/pipeline.py` -> the S3 upload path (same bug, only reached when S3 is enabled, but a half-fixed path is the kind of thing that bites later)

The mapping is deterministic, so a directory created on one OS is found again on another. POSIX behaviour is unchanged for ids containing no forbidden characters.

### Verified

On v1.2.3 (`09bfa62`), Windows 11, Python 3.12, against a real place:

- before: the images task raised `WinError 123`, **0 files** written
- after: `review_images/0x89accda1eff33585_0x8347540c3719d897/{profiles,reviews}` created, **29 files** written (25 profile pictures, 4 review images)
- `_fs_safe` checked in both directions: a colon-bearing id is rewritten, an already-safe `ChIJ...` id is returned unchanged
- both touched modules compile under `-W error::SyntaxWarning`

Thanks for the tool, it does exactly what it says.
